### PR TITLE
Add support for Qt6 and import/export macros for DLLs

### DIFF
--- a/ivef-sdk/bindings/build/qt/qt.pro
+++ b/ivef-sdk/bindings/build/qt/qt.pro
@@ -12,11 +12,17 @@ OBJECTS_DIR = ./tmp/obj
 TEMPLATE = lib
  win32:TARGET = ivef
   unix:TARGET = ivef1
+build_pass:CONFIG(debug, debug|release) {
+ win32:TARGET = $$join(TARGET,,,d)
+}
 INCLUDEPATH += $$TARGET_QT_DIR/include
+
+DEFINES += SCHEMAIVEF_BUILD
+staticlib:DEFINES += SCHEMAIVEF_BUILD_STATIC
 
 QT += xml
 VERSION = $$IVEF_VERSION
 
-SOURCES += $$TARGET_QT_DIR/src/*.cpp
-HEADERS += $$TARGET_QT_DIR/include/*.h
+SOURCES += $$shell_path($$TARGET_QT_DIR/src/*.cpp)
+HEADERS += $$shell_path($$TARGET_QT_DIR/include/*.h)
 

--- a/ivef-sdk/bindings/build/qt/qt.pro
+++ b/ivef-sdk/bindings/build/qt/qt.pro
@@ -21,6 +21,9 @@ DEFINES += SCHEMAIVEF_BUILD
 staticlib:DEFINES += SCHEMAIVEF_BUILD_STATIC
 
 QT += xml
+greaterThan(QT_MAJOR_VERSION, 5) {
+  QT += core5compat
+}
 VERSION = $$IVEF_VERSION
 
 SOURCES += $$shell_path($$TARGET_QT_DIR/src/*.cpp)

--- a/ivef-sdk/bindings/generate/generate.pro
+++ b/ivef-sdk/bindings/generate/generate.pro
@@ -8,8 +8,7 @@ TARGET_QT_DIR = $$IVEF_TARGETS_DIR/qt
 
 ! exists( $$TARGET_QT_DIR ) {
     message(Create build target dir: $$TARGET_QT_DIR)
-    unix:system( mkdir $$TARGET_QT_DIR )
-    win32:system( mkdir ..\\..\\build\\targets\\qt )
+    mkpath( $$TARGET_QT_DIR )
 }
 
 gentarget1.commands = $$IVEF_GENERATOR_DIR/$$IVEF_GENERATOR_BIN --file=$$IVEF_SCHEMA --qt --out=$$TARGET_QT_DIR --prefix=IVEF
@@ -22,8 +21,7 @@ TARGET_JAVA_DIR = $$IVEF_TARGETS_DIR/java
 
 ! exists( $$TARGET_JAVA_DIR ) {
     message(Create build target dir: $$TARGET_JAVA_DIR)
-    unix:system( mkdir $$TARGET_JAVA_DIR )
-    win32:system( mkdir ..\\..\\build\\targets\\java )
+    mkpath( $$TARGET_JAVA_DIR )
 }
 
 gentarget2.commands = $$IVEF_GENERATOR_DIR/$$IVEF_GENERATOR_BIN --file=$$IVEF_SCHEMA --java --out=$$TARGET_JAVA_DIR --prefix=IVEF
@@ -36,8 +34,7 @@ TARGET_PHP_DIR = $$IVEF_TARGETS_DIR/php
 
 ! exists( $$TARGET_PHP_DIR ) {
     message(Create build target dir: $$TARGET_PHP_DIR)
-    unix:system( mkdir $$TARGET_PHP_DIR )
-    win32:system( mkdir ..\\..\\build\\targets\\php )
+    mkpath( $$TARGET_PHP_DIR )
 }
 
 gentarget3.commands = $$IVEF_GENERATOR_DIR/$$IVEF_GENERATOR_BIN --file=$$IVEF_SCHEMA --php --out=$$TARGET_PHP_DIR --prefix=IVEF
@@ -50,8 +47,7 @@ TARGET_OBJC_DIR = $$IVEF_TARGETS_DIR/objc
 
 ! exists( $$TARGET_OBJC_DIR ) {
     message(Create build target dir: $$TARGET_OBJC_DIR)
-    unix:system( mkdir $$TARGET_OBJC_DIR )
-    win32:system( mkdir ..\\..\\build\\targets\\objc )
+    mkpath( $$TARGET_OBJC_DIR )
 }
 
 gentarget4.commands = $$IVEF_GENERATOR_DIR/$$IVEF_GENERATOR_BIN --file=$$IVEF_SCHEMA --objc --out=$$TARGET_OBJC_DIR --prefix=IL
@@ -63,5 +59,5 @@ QMAKE_CLEAN += $$TARGET_OBJC_DIR/*
 MOC_DIR = ./tmp/moc
 OBJECTS_DIR = ./tmp/obj
 
-TEMPLATE = lib
+TEMPLATE = aux
 TARGET = dummy

--- a/ivef-sdk/schema2code/schema2code.pro
+++ b/ivef-sdk/schema2code/schema2code.pro
@@ -16,6 +16,9 @@ DEFINES += VERSION=$$IVEF_VERSION
 
 #CONFIG += warn_on stl qt release console
 QT += network xml
+greaterThan(QT_MAJOR_VERSION, 5) {
+   QT += core5compat
+}
 macx {
    CONFIG -= app_bundle
 }

--- a/ivef-sdk/schema2code/src/cmdlineoption.cpp
+++ b/ivef-sdk/schema2code/src/cmdlineoption.cpp
@@ -21,6 +21,7 @@
 
 #include <QStringList>
 #include <QStack>
+#include <QRegExp>
 
 #include "cmdlineoption.h"
 

--- a/ivef-sdk/schema2code/src/codegenqt.cpp
+++ b/ivef-sdk/schema2code/src/codegenqt.cpp
@@ -356,6 +356,17 @@ void CodeGenQT::classFiles() {
                 headerFileOut << "#include \"" << fileBaseName(attr->type()) << ".h\"\n";
             }
         }
+        headerFileOut << "#ifndef SCHEMA" << m_prefix.toUpper() << "_EXPORT\n";
+        headerFileOut << "# ifdef SCHEMA" << m_prefix.toUpper() << "_BUILD_STATIC\n";
+        headerFileOut << "#  define SCHEMA" << m_prefix.toUpper() << "_EXPORT\n";
+        headerFileOut << "# else\n";
+        headerFileOut << "#  ifdef SCHEMA" << m_prefix.toUpper() << "_BUILD\n";
+        headerFileOut << "#   define SCHEMA" << m_prefix.toUpper() << "_EXPORT Q_DECL_EXPORT\n";
+        headerFileOut << "#  else\n";
+        headerFileOut << "#   define SCHEMA" << m_prefix.toUpper() << "_EXPORT Q_DECL_IMPORT\n";
+        headerFileOut << "#  endif\n";
+        headerFileOut << "# endif\n";
+        headerFileOut << "#endif\n";
 
         headerFileOut << "\nclass XmlStreamReader;\n";
 
@@ -380,7 +391,7 @@ void CodeGenQT::classFiles() {
         if (obj->hasBaseClass()) {
             baseClass = obj->baseClass();
         }
-        headerFileOut << "class " << className(name) << " : public " << baseClass << " { \n";
+        headerFileOut << "class SCHEMA" << m_prefix.toUpper() << "_EXPORT " << className(name) << " : public " << baseClass << " { \n";
         headerFileOut << "    Q_OBJECT\n\n";
 
         // public section
@@ -1226,6 +1237,17 @@ void CodeGenQT::parserFile() {
             headerFileOut << "#include \"" << fileBaseName(obj->name()) << ".h\"\n";
         }
     }
+    headerFileOut << "#ifndef SCHEMA" << m_prefix.toUpper() << "_EXPORT\n";
+    headerFileOut << "# ifdef SCHEMA" << m_prefix.toUpper() << "_BUILD_STATIC\n";
+    headerFileOut << "#  define SCHEMA" << m_prefix.toUpper() << "_EXPORT\n";
+    headerFileOut << "# else\n";
+    headerFileOut << "#  ifdef SCHEMA" << m_prefix.toUpper() << "_BUILD\n";
+    headerFileOut << "#   define SCHEMA" << m_prefix.toUpper() << "_EXPORT Q_DECL_EXPORT\n";
+    headerFileOut << "#  else\n";
+    headerFileOut << "#   define SCHEMA" << m_prefix.toUpper() << "_EXPORT Q_DECL_IMPORT\n";
+    headerFileOut << "#  endif\n";
+    headerFileOut << "# endif\n";
+    headerFileOut << "#endif\n";
     headerFileOut << "class XmlStreamReader;\n";
 
     if ( m_namespace ) {
@@ -1236,7 +1258,7 @@ void CodeGenQT::parserFile() {
     headerFileOut << "//!\n";
 
     // define the class
-    headerFileOut << "class " << className(name) << " : public QObject { \n";
+    headerFileOut << "class SCHEMA" << m_prefix.toUpper() << "_EXPORT " << className(name) << " : public QObject { \n";
     headerFileOut << "    Q_OBJECT\n\n";
 
     // public section

--- a/ivef-sdk/schema2code/src/codegenqt.cpp
+++ b/ivef-sdk/schema2code/src/codegenqt.cpp
@@ -414,7 +414,7 @@ void CodeGenQT::classFiles() {
 
         headerFileOut << "    //! == operator\n";
         headerFileOut << "    //!\n";
-        headerFileOut << "    bool operator==(const " << className(name) << "& val);\n"; // = operator
+        headerFileOut << "    bool operator==(const " << className(name) << "& val) const;\n"; // = operator
 
         // all attributes
         for(int j=0; j < attributes.size(); j++) {
@@ -651,7 +651,7 @@ void CodeGenQT::classFiles() {
         classFileOut << "        QXmlStreamReader::TokenType token = xml.readNext();\n";
         classFileOut << "        switch ( token )\n        {\n";
         classFileOut << "        case QXmlStreamReader::EndElement:\n";
-        classFileOut << "            if (  xml.name() == \""<< name <<"\" )\n";
+        classFileOut << "            if (  xml.name() == QStringLiteral(\""<< name <<"\") )\n";
         classFileOut << "                stop = true;\n";
         classFileOut << "            break;\n";
 
@@ -664,12 +664,12 @@ void CodeGenQT::classFiles() {
                 if ( !element )
                 {
                     classFileOut << "        case QXmlStreamReader::StartElement:\n";
-                    classFileOut << "            if ( xml.name() == \"" << attr->name() <<"\" )\n";
+                    classFileOut << "            if ( xml.name() == QStringLiteral(\"" << attr->name() <<"\") )\n";
                     element = true;
                 }
                 else
                 {
-                    classFileOut << "            else if ( xml.name() == \"" << attr->name() <<"\" )\n";
+                    classFileOut << "            else if ( xml.name() == QStringLiteral(\"" << attr->name() <<"\") )\n";
                 }
                 classFileOut << "            {\n";
                 if ( attr->isSimpleElement() )
@@ -680,7 +680,7 @@ void CodeGenQT::classFiles() {
                 {
                     classFileOut << "                " << attr->name() << " val( xml );\n";
                 }
-                classFileOut << "                if ( xml.name() != \"" << attr->name() << "\" )\n";
+                classFileOut << "                if ( xml.name() != QStringLiteral(\"" << attr->name() << "\") )\n";
                 classFileOut << "                    xml.raiseError( \"tag mismatch " << attr->name() << "\" );\n";
                 if ( attr->isScalar() )
                 {
@@ -735,9 +735,9 @@ void CodeGenQT::classFiles() {
         classFileOut << "// compare\n";
         classFileOut << "bool " << className(name) << "::operator==(const " << className(name) << " &";
         if (attributes.empty()) { // val is unused variable
-            classFileOut << "/*val*/) {\n\n";
+            classFileOut << "/*val*/) const {\n\n";
         } else {
-            classFileOut << "val) {\n\n";
+            classFileOut << "val) const {\n\n";
         }
         for(int j=0; j < attributes.size(); j++) {
             XSDAttribute *attr = attributes.at(j);
@@ -1401,15 +1401,15 @@ void CodeGenQT::parserFile() {
         if ( !obj->isEmbedded() && (obj->name() != "Schema") && !obj->isSimpleElement()) {
             if ( !element )
             {
-                classFileOut << "            if( m_xml->name()==\"" << className(obj->name()) << "\" )\n";
+                classFileOut << "            if( m_xml->name()==QStringLiteral(\"" << className(obj->name()) << "\") )\n";
                 element = true;
             }
             else
-                classFileOut << "            else if( m_xml->name()==\"" << className(obj->name()) << "\" )\n";
+                classFileOut << "            else if( m_xml->name()==QStringLiteral(\"" << className(obj->name()) << "\") )\n";
 
             classFileOut << "            {\n";
             classFileOut << "                " << className(obj->name()) << " obj( *m_xml );\n";
-            classFileOut << "                if ( m_xml->name() != \"" << className(obj->name()) << "\" )\n";
+            classFileOut << "                if ( m_xml->name() != QStringLiteral(\"" << className(obj->name()) << "\") )\n";
             classFileOut << "                    m_xml->raiseError( \"tag mismatch " << className(obj->name()) << "\" );\n";
             classFileOut << "                else\n";
             classFileOut << "                {\n";

--- a/ivef-sdk/schema2code/src/xsdobject.cpp
+++ b/ivef-sdk/schema2code/src/xsdobject.cpp
@@ -37,11 +37,11 @@ void XSDObject::dump() {
 		std::cout << "object baseClass         " << QString(m_baseClass).toLatin1().data() << std::endl;
         }
 	std::cout << "object document     " << QString(m_docu).toLatin1().data() << std::endl;
-	std::cout << "object isMerged     " << QString(m_merged).toLatin1().data() << std::endl;
-	std::cout << "object isType       " << QString(m_type).toLatin1().data() << std::endl;
-        std::cout << "object isSimple     " << QString(m_simple).toLatin1().data() << std::endl;
-	std::cout << "object isRoot       " << QString(m_root).toLatin1().data() << std::endl;
-	std::cout << "object isEmbedded   " << QString(m_isEmbedded).toLatin1().data() << std::endl;
+	std::cout << "object isMerged     " << QString::number(m_merged).toLatin1().data() << std::endl;
+	std::cout << "object isType       " << QString::number(m_type).toLatin1().data() << std::endl;
+        std::cout << "object isSimple     " << QString::number(m_simple).toLatin1().data() << std::endl;
+	std::cout << "object isRoot       " << QString::number(m_root).toLatin1().data() << std::endl;
+	std::cout << "object isEmbedded   " << QString::number(m_isEmbedded).toLatin1().data() << std::endl;
         for (int h=0; h < m_attributes.size(); h++) {
 		std::cout << "object attribute    " << QString(m_attributes.at(h)->name()).toLatin1().data() << std::endl;
         }


### PR DESCRIPTION
Only 4 issues stopping Qt6 support:
- operator== needs to be const for QList to support it.
- QString can't take a bool in it's constuctor.
- QXMLStringReader->name() now returns a QStringView instead of a QStringRef. QStringView doesn't support comparison against raw strings.
- QRegExp has been moved to core5compat and there needs to be a #include for it.