### PR TITLE
More Qt 6 compatibility changes

### DIFF
--- a/ivef-sdk/bindings/build/java/java.pro
+++ b/ivef-sdk/bindings/build/java/java.pro
@@ -34,5 +34,5 @@ else {
 MOC_DIR = ./tmp/moc
 OBJECTS_DIR = ./tmp/obj
 
-TEMPLATE = lib
+TEMPLATE = aux
 TARGET = dummy

--- a/ivef-sdk/examples/ilisten/ilisten.pro
+++ b/ivef-sdk/examples/ilisten/ilisten.pro
@@ -19,6 +19,9 @@ DEFINES += VERSION=$$IVEF_VERSION
 unix:DEFINES += HAVE_ZLIB
 
 QT += network xml
+greaterThan(QT_MAJOR_VERSION, 5) {
+  QT += core5compat
+}
 macx {
    CONFIG -= app_bundle
    LIBS += -F$$IVEF_BUILD_DIR/targets/qt/lib -framework ivef

--- a/ivef-sdk/examples/ilisten/src/cmdlineoption.cpp
+++ b/ivef-sdk/examples/ilisten/src/cmdlineoption.cpp
@@ -21,6 +21,7 @@
 
 #include <QStringList>
 #include <QStack>
+#include <QRegExp>
 
 #include "cmdlineoption.h"
 

--- a/ivef-sdk/examples/ilisten/src/ivefstreamhandler.cpp
+++ b/ivef-sdk/examples/ilisten/src/ivefstreamhandler.cpp
@@ -148,7 +148,11 @@ void IVEFStreamHandler::connectToServer(QString host, int port, QString user, QS
         }
 
         m_log = new QTextStream(file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         m_log->setCodec("UTF-8");
+#else
+        m_log->setEncoding(QStringConverter::Utf8);
+#endif
         *m_log << "<xml>\n"; // create a start tag
         m_log->flush();
     } else {

--- a/ivef-sdk/examples/isim/isim.pro
+++ b/ivef-sdk/examples/isim/isim.pro
@@ -59,5 +59,5 @@ QMAKE_CLEAN += $$IVEF_EXAMPLES_DIR/test.xml
 MOC_DIR = ./tmp/moc
 OBJECTS_DIR = ./tmp/obj
 
-TEMPLATE = lib
+TEMPLATE = aux
 TARGET = dummy

--- a/ivef-sdk/schema2code/include/handler.h
+++ b/ivef-sdk/schema2code/include/handler.h
@@ -30,6 +30,7 @@ public:
     Handler() { };
 
     bool startDocument ();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     bool startElement (const QStringRef &namespaceURI,
                        const QStringRef &localName,
                        const QStringRef &qName,
@@ -39,6 +40,17 @@ public:
     bool endElement (const QStringRef &namespaceURI,
                      const QStringRef &localName,
                      const QStringRef &qName );
+#else
+    bool startElement (QStringView namespaceURI,
+                       QStringView localName,
+                       QStringView qName,
+                       const QXmlStreamAttributes &atts);
+
+    bool characters (QStringView ch);
+    bool endElement (QStringView namespaceURI,
+                     QStringView localName,
+                     QStringView qName );
+#endif
     bool endDocument ();
 
     QVector<XSDObject*> objects();

--- a/ivef-sdk/schema2code/src/handler.cpp
+++ b/ivef-sdk/schema2code/src/handler.cpp
@@ -132,9 +132,15 @@ void Handler::handleStartOfElement (const QString & qName, const QXmlStreamAttri
 
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 bool Handler::startElement (const QStringRef & /* namespaceURI */,
                             const QStringRef & /* localName */,
                             const QStringRef &qualifiedName,
+#else
+bool Handler::startElement (const QStringView /* namespaceURI */,
+                            const QStringView /* localName */,
+                            const QStringView qualifiedName,
+#endif
                             const QXmlStreamAttributes & atts) {
 
     // some xsd use the xsd:<token> style
@@ -304,17 +310,26 @@ bool Handler::startElement (const QStringRef & /* namespaceURI */,
     return true;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 bool Handler::characters ( const QStringRef &ch ) {
+#else
+bool Handler::characters ( const QStringView ch ) {
+#endif
 
     //std::cout << QString("CH:        [%1]").arg(ch.trimmed()).toLatin1().data() << std::endl;
     m_doc = ch.trimmed().toString();
     return true;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 bool Handler::endElement ( const QStringRef & /* namespaceURI */,
                            const QStringRef & /* localName */,
                            const QStringRef & qualifiedName ) {
-
+#else
+bool Handler::endElement ( const QStringView /* namespaceURI */,
+                           const QStringView /* localName */,
+                           const QStringView qualifiedName ) {
+#endif
     // some xsd use the xsd:<token> style
     QString qName = qualifiedName.toString();
     qName.replace(QString("xsd:"), QString("xs:"));

--- a/ivef-sdk/tests/java/java.pro
+++ b/ivef-sdk/tests/java/java.pro
@@ -37,5 +37,5 @@ else {
 MOC_DIR = ./tmp/moc
 OBJECTS_DIR = ./tmp/obj
 
-TEMPLATE = lib
+TEMPLATE = aux
 TARGET = dummy


### PR DESCRIPTION
Fixed the ilisten example.
I didn't notice the change to QXmlStreamReader from QXmlSimpleReader in schema2code (40b15fa524b5b806b606f0e4e8986db4c83380dd)
QXmlStreamReader methods return QStringView in Qt 6 instead of QStringRef.
Note that QStringView is designed to be passed by value not be reference.